### PR TITLE
Update required elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule IExHistory2.MixProject do
     [
       app: :iex_history2,
       version: "5.4.0",
-      elixir: "~> 1.16.0-otp-26",
+      elixir: "~> 1.16",
       description: description(),
       package: package(),
       name: "IExHistory2",	


### PR DESCRIPTION
`"~> 1.16.0-otp-26"` is not really a valid version specifier so when I was running on `1.17.3-otp-27` I got an error:
```
==> iex_history2
warning: the dependency :iex_history2 requires Elixir "~> 1.16.0-otp-26" but you are running on v1.17.3
```
This PR relaxes the version to allow 1.16.0 or greater